### PR TITLE
Set up Spring Security authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
@@ -43,6 +47,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/group23/ControllerStructure.java
+++ b/src/main/java/org/group23/ControllerStructure.java
@@ -1,8 +1,12 @@
 package org.group23;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
 
 @org.springframework.stereotype.Controller
 public class ControllerStructure {
@@ -20,6 +24,9 @@ public class ControllerStructure {
 
     @PostMapping("/saveSurveyName")
     public String saveSurveyName(@ModelAttribute("survey") Survey survey) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = auth.getName();
+        survey.setAuthor(username);
         surveyRepository.save(survey);
         return "redirect:/addRemoveQuestions/" + survey.getId();
     }
@@ -28,12 +35,17 @@ public class ControllerStructure {
     public String addRemoveQuestionsForm(@PathVariable Long surveyId, Model model) {
         // Get the survey by ID
         Survey survey = surveyRepository.findById(surveyId).orElse(null);
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = auth.getName();
 
-        if (survey != null) {
+        if (survey != null && Objects.equals(username, survey.getAuthor())) {
             model.addAttribute("survey", survey);
             return "addRemoveQuestions";
         } else {
             // Handle survey not found
+            model.addAttribute(
+                    "message",
+                    "The survey was not found, or you do not have permission to edit it.");
             return "error";
         }
     }

--- a/src/main/java/org/group23/ControllerStructure.java
+++ b/src/main/java/org/group23/ControllerStructure.java
@@ -1,7 +1,6 @@
 package org.group23;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.ui.Model;
@@ -52,7 +51,6 @@ public class ControllerStructure {
     }
 
     @PostMapping("/addQuestion/{surveyId}")
-    @PreAuthorize("#survey.author == authentication.name")
     public String addQuestion(
             @PathVariable Long surveyId,
             @ModelAttribute("survey") Survey survey,
@@ -66,8 +64,10 @@ public class ControllerStructure {
             return "error";
         }
         // Get the survey by ID to ensure we have the latest data
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = auth.getName();
         Survey updatedSurvey = surveyRepository.findById(surveyId).orElse(null);
-        if (updatedSurvey != null) {
+        if (updatedSurvey != null && Objects.equals(username, updatedSurvey.getAuthor())) {
             // Create a text question and add it to the survey
             TextQuestion textQuestion = new TextQuestion(questionText);
             updatedSurvey.addQuestion(textQuestion);

--- a/src/main/java/org/group23/Survey.java
+++ b/src/main/java/org/group23/Survey.java
@@ -14,6 +14,8 @@ public class Survey {
 
     private String name;
 
+    private String author;
+
     @OneToMany(cascade = CascadeType.ALL)
     private List<Question> questions;
 
@@ -21,7 +23,7 @@ public class Survey {
         this.questions = new ArrayList<>();
     }
 
-    public Survey(String name){
+    public Survey(String name, String author){
         this();
         this.name = name;
     }
@@ -56,6 +58,14 @@ public class Survey {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
     }
 
 }

--- a/src/main/java/org/group23/Survey.java
+++ b/src/main/java/org/group23/Survey.java
@@ -26,6 +26,7 @@ public class Survey {
     public Survey(String name, String author){
         this();
         this.name = name;
+        this.author = author;
     }
 
     public void addQuestion(Question question){

--- a/src/main/java/org/group23/SurveyMonkeyAppApplication.java
+++ b/src/main/java/org/group23/SurveyMonkeyAppApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguratio
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @SpringBootApplication
-public class SurveyMonkeyAppApplication extends WebMvcAutoConfiguration {
+public class SurveyMonkeyAppApplication {
     public static void main(String[] args) {
         SpringApplication.run(SurveyMonkeyAppApplication.class, args);
     }

--- a/src/main/java/org/group23/SurveyMonkeyAppApplication.java
+++ b/src/main/java/org/group23/SurveyMonkeyAppApplication.java
@@ -2,9 +2,11 @@ package org.group23;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @SpringBootApplication
-public class SurveyMonkeyAppApplication {
+public class SurveyMonkeyAppApplication extends WebMvcAutoConfiguration {
     public static void main(String[] args) {
         SpringApplication.run(SurveyMonkeyAppApplication.class, args);
     }

--- a/src/main/java/org/group23/config/MvcConfig.java
+++ b/src/main/java/org/group23/config/MvcConfig.java
@@ -1,0 +1,15 @@
+package org.group23.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class MvcConfig implements WebMvcConfigurer {
+
+    public void addViewControllers(ViewControllerRegistry registry) {
+        // Use a simple controller for the login page
+        registry.addViewController("/login").setViewName("login");
+    }
+
+}

--- a/src/main/java/org/group23/config/MvcConfig.java
+++ b/src/main/java/org/group23/config/MvcConfig.java
@@ -7,8 +7,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class MvcConfig implements WebMvcConfigurer {
 
+    /**
+     * Adds simple default controllers for specified paths and views.
+     * @param registry the ViewControllerRegistry keeping track of controllers
+     */
     public void addViewControllers(ViewControllerRegistry registry) {
-        // Use a simple controller for the login page
+        // Use a simple controller for the login and index page
         registry.addViewController("/").setViewName("index");
         registry.addViewController("/login").setViewName("login");
     }

--- a/src/main/java/org/group23/config/MvcConfig.java
+++ b/src/main/java/org/group23/config/MvcConfig.java
@@ -9,6 +9,7 @@ public class MvcConfig implements WebMvcConfigurer {
 
     public void addViewControllers(ViewControllerRegistry registry) {
         // Use a simple controller for the login page
+        registry.addViewController("/").setViewName("index");
         registry.addViewController("/login").setViewName("login");
     }
 

--- a/src/main/java/org/group23/config/SecurityConfig.java
+++ b/src/main/java/org/group23/config/SecurityConfig.java
@@ -18,17 +18,34 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 @EnableWebSecurity
 public class SecurityConfig {
 
+    /**
+     * Returns a builder used for MVC matcher patterns.
+     * This is required to remove ambiguity due to a vulnerability.
+     * @param introspector the introspector, automatically injected
+     * @return the builder to use when creating patterns
+     */
     @Bean
     MvcRequestMatcher.Builder mvc(HandlerMappingIntrospector introspector) {
         return new MvcRequestMatcher.Builder(introspector);
     }
 
+    /**
+     * Returns the password encoder to use for this application.
+     * @return the password encoder
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
+    /**
+     * Returns the application's user details service.
+     * This service is responsible for retrieving user information for authentication.
+     * @return the user details service
+     */
     @Bean
     public InMemoryUserDetailsManager userDetailsService() {
+        // Manually defines three users.
         UserDetails user1 = User.withUsername("Andrei")
                 .password(passwordEncoder().encode("Andrei"))
                 .roles("USER")
@@ -47,14 +64,17 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
         http
+                // Allow all requests to the home page
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers(mvc.pattern("/")).permitAll()
                         .anyRequest().authenticated()
                 )
+                // Define the login path, and allow all requests to it
                 .formLogin((form) -> form
                         .loginPage("/login")
                         .permitAll()
                 )
+                // Allow all logouts
                 .logout((logout) -> logout.permitAll());
 
         return http.build();

--- a/src/main/java/org/group23/config/SecurityConfig.java
+++ b/src/main/java/org/group23/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package org.group23.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    MvcRequestMatcher.Builder mvc(HandlerMappingIntrospector introspector) {
+        return new MvcRequestMatcher.Builder(introspector);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService() {
+        UserDetails user1 = User.withUsername("Andrei")
+                .password(passwordEncoder().encode("Andrei"))
+                .roles("USER")
+                .build();
+        UserDetails user2 = User.withUsername("Cam")
+                .password(passwordEncoder().encode("Cam"))
+                .roles("USER")
+                .build();
+        UserDetails admin = User.withUsername("admin")
+                .password(passwordEncoder().encode("admin"))
+                .roles("ADMIN")
+                .build();
+        return new InMemoryUserDetailsManager(user1, user2, admin);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
+        http
+                .authorizeHttpRequests((requests) -> requests
+                        .requestMatchers(mvc.pattern("/")).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin((form) -> form
+                        .loginPage("/login")
+                        .permitAll()
+                )
+                .logout((logout) -> logout.permitAll());
+
+        return http.build();
+    }
+}

--- a/src/main/resources/templates/addRemoveQuestions.html
+++ b/src/main/resources/templates/addRemoveQuestions.html
@@ -6,6 +6,7 @@
     <title>Modify questions</title>
 </head>
 <body>
+    <div th:replace="fragments/header"></div>
     <h1>Add or remove questions</h1>
     <p th:text="${survey.name}"></p>
 
@@ -28,7 +29,7 @@
             <li>
                 <span th:text="${question.question}"></span>
                 <form th:action="@{/deleteQuestion/{surveyId}/{questionId}(surveyId=${survey.id}, questionId=${question.id})}" method="post" style="display: inline;">
-                    <input type="submit" value="Del">
+                    <input type="submit" value="Delete">
                 </form>
                 <p></p> <!-- For spacing, this will be improved anyway later -->
             </li>

--- a/src/main/resources/templates/addRemoveQuestions.html
+++ b/src/main/resources/templates/addRemoveQuestions.html
@@ -24,10 +24,15 @@
 
     <!-- Display existing questions and allow deletion -->
     <ul>
-        <p th:each="question : ${survey.questions}">
-            <span th:text="${question.question}"></span>
-            <a th:href="@{'/deleteQuestion/' + ${survey.id} + '/' + ${question.id}}"><button>Delete</button></a>
-        </p>
+        <th:block th:each="question : ${survey.questions}">
+            <li>
+                <span th:text="${question.question}"></span>
+                <form th:action="@{/deleteQuestion/{surveyId}/{questionId}(surveyId=${survey.id}, questionId=${question.id})}" method="post" style="display: inline;">
+                    <input type="submit" value="Del">
+                </form>
+                <p></p> <!-- For spacing, this will be improved anyway later -->
+            </li>
+        </th:block>
     </ul>
 </body>
 </html>

--- a/src/main/resources/templates/createSurvey.html
+++ b/src/main/resources/templates/createSurvey.html
@@ -6,6 +6,7 @@
     <title>Create survey</title>
 </head>
 <body>
+    <div th:replace="fragments/header"></div>
     <h1>Create your survey</h1>
     <form th:action="@{/saveSurveyName}" th:object="${survey}" method="post">
         <label for="name">Enter your survey name:</label>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,3 +1,4 @@
+<!-- This is a reusable fragment that should be added at the top of every page (except login). -->
 <header>
     <nav>
         <a href="/">Home</a>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,8 @@
+<header>
+    <nav>
+        <a href="/">Home</a>
+        <form th:action="@{/logout}" method="post" style="display: inline;">
+            <div><input type="submit" value="Sign Out"/></div>
+        </form>
+    </nav>
+</header>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -3,10 +3,11 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Welcome to SurveyMonkey</title>
+    <title>Mini Survey Monkey - Welcome</title>
 </head>
 <body>
-    <h1 th:text="${message}">Welcome!</h1>
+    <div th:replace="fragments/header"></div>
+    <h1>Welcome!</h1>
     <a href="/createSurvey" class="btn btn-primary"><button>Create survey</button></a>
 </body>
 </html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
+    <head>
+        <title>Mini Survey Monkey - Login</title>
+    </head>
+    <body>
+        <div th:if="${param.error}"> <!-- A user that fails a login will arrive to this page with this URL param set. -->
+            Invalid username and password.
+        </div>
+        <div th:if="${param.logout}"> <!-- A user logging out will arrive to this page with this URL param set. -->
+            You have been logged out.
+        </div>
+        <form th:action="@{/login}" method="post">
+            <div><label> User Name : <input type="text" name="username"/> </label></div>
+            <div><label> Password: <input type="password" name="password"/> </label></div>
+            <div><input type="submit" value="Sign In"/></div>
+        </form>
+    </body>
+</html>

--- a/src/main/resources/templates/surveyCreated.html
+++ b/src/main/resources/templates/surveyCreated.html
@@ -6,6 +6,7 @@
     <title>Survey created</title>
 </head>
 <body>
+    <div th:replace="fragments/header"></div>
     <h1>Survey created successfully</h1>
     <p>The survey <span th:text="${survey.name}"></span> has been created</p>
     <a th:href="@{/createSurvey}" class="btn btn-primary"><button>Create another survey</button></a>

--- a/src/main/resources/templates/surveyResults.html
+++ b/src/main/resources/templates/surveyResults.html
@@ -2,12 +2,13 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>Survey Results</title>
+    <meta charset="UTF-8">
+    <title>Survey Results</title>
 </head>
 <body>
-<h2>Survey Results</h2>
+    <div th:replace="fragments/header"></div>
+    <h2>Survey Results</h2>
 
-<p th:text="${message}"></p>
+    <p th:text="${message}"></p>
 </body>
 </html>

--- a/src/main/resources/templates/viewResults.html
+++ b/src/main/resources/templates/viewResults.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Survey results</title>
+    <script src="../static/header.js" type="text/javascript" defer></script>
 </head>
 <!--<body>
     <h1>Result of your survey</h1>

--- a/src/test/java/org/group23/ControllerStructureTest.java
+++ b/src/test/java/org/group23/ControllerStructureTest.java
@@ -29,6 +29,14 @@ public class ControllerStructureTest {
 
     @Test
     @DirtiesContext
+    public void accessHomepageUnauthenticated() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("index"));
+    }
+
+    @Test
+    @DirtiesContext
     @WithMockUser(username = "user1")
     public void createSurveyForm() throws Exception {
         this.mockMvc.perform(MockMvcRequestBuilders.get("/createSurvey"))

--- a/src/test/java/org/group23/ControllerStructureTest.java
+++ b/src/test/java/org/group23/ControllerStructureTest.java
@@ -5,9 +5,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
@@ -19,11 +22,12 @@ public class ControllerStructureTest {
 
     @BeforeEach
     public void setup() {
-        Survey survey = new Survey("SurveyMonkey");
+        Survey survey = new Survey("SurveyMonkey", "user1");
         surveyRepository.save(survey);
     }
 
     @Test
+    @WithMockUser(username = "user1")
     public void createSurveyForm() throws Exception {
         this.mockMvc.perform(MockMvcRequestBuilders.get("/createSurvey"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -31,21 +35,23 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @WithMockUser(username = "user1")
     public void addQuestion() throws Exception {
-        Survey survey = new Survey("SurveyMonkey");
+        Survey survey = new Survey("SurveyMonkey", "user1");
         this.surveyRepository.save(survey);
 
         String textQuestion = "Who is Joe?";
 
         this.mockMvc.perform(MockMvcRequestBuilders.post("/addQuestion/{surveyId}", survey.getId())
-                        .param("questionText", textQuestion))
+                        .param("questionText", textQuestion).with(csrf()))
                 .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
                 .andExpect(MockMvcResultMatchers.view().name("redirect:/addRemoveQuestions/" + survey.getId()));
     }
 
     @Test
+    @WithMockUser(username = "user1")
     public void deleteQuestion() throws Exception {
-        Survey survey = new Survey("SurveyMonkey");
+        Survey survey = new Survey("SurveyMonkey", "user1");
         this.surveyRepository.save(survey);
 
         Question question = new TextQuestion("Who is Joe?");
@@ -58,8 +64,9 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @WithMockUser(username = "user1")
     public void addRemoveQuestionsForm() throws Exception {
-        Survey survey = new Survey("SurveyMonkey");
+        Survey survey = new Survey("SurveyMonkey", "user1");
         this.surveyRepository.save(survey);
 
         this.mockMvc.perform(MockMvcRequestBuilders.get("/addRemoveQuestions/{id}", survey.getId()))
@@ -69,6 +76,7 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @WithMockUser(username = "user1")
     public void saveSurvey() throws Exception {
         this.mockMvc.perform(MockMvcRequestBuilders.get("/saveSurvey"))
                 .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
@@ -76,19 +84,21 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @WithMockUser(username = "user1")
     public void saveSurveyName() throws Exception {
-        Survey survey = new Survey("SurveyMonkey");
+        Survey survey = new Survey("SurveyMonkey", "user1");
         this.surveyRepository.save(survey);
 
         this.mockMvc.perform(MockMvcRequestBuilders.post("/saveSurveyName")
-                        .flashAttr("survey", survey))
+                        .flashAttr("survey", survey).with(csrf()))
                 .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
                 .andExpect(MockMvcResultMatchers.view().name("redirect:/addRemoveQuestions/" + survey.getId()));
     }
 
     @Test
+    @WithMockUser(username = "user1")
     public void surveyCreated() throws Exception {
-        Survey survey = new Survey("SurveyMonkey");
+        Survey survey = new Survey("SurveyMonkey", "user1");
         this.surveyRepository.save(survey);
 
         this.mockMvc.perform(MockMvcRequestBuilders.get("/surveyCreated/1"))

--- a/src/test/java/org/group23/ControllerStructureTest.java
+++ b/src/test/java/org/group23/ControllerStructureTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -27,6 +28,7 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @DirtiesContext
     @WithMockUser(username = "user1")
     public void createSurveyForm() throws Exception {
         this.mockMvc.perform(MockMvcRequestBuilders.get("/createSurvey"))
@@ -35,6 +37,7 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @DirtiesContext
     @WithMockUser(username = "user1")
     public void addQuestion() throws Exception {
         Survey survey = new Survey("SurveyMonkey", "user1");
@@ -49,6 +52,7 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @DirtiesContext
     @WithMockUser(username = "user1")
     public void deleteQuestion() throws Exception {
         Survey survey = new Survey("SurveyMonkey", "user1");
@@ -58,12 +62,14 @@ public class ControllerStructureTest {
         survey.addQuestion(question);
         this.surveyRepository.save(survey);
 
-        this.mockMvc.perform(MockMvcRequestBuilders.get("/deleteQuestion/{surveyId}/{questionId}", survey.getId(), question.getId()))
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/deleteQuestion/{surveyId}/{questionId}", survey.getId(), question.getId())
+                        .with(csrf()))
                 .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
                 .andExpect(MockMvcResultMatchers.view().name("redirect:/addRemoveQuestions/" + survey.getId()));
     }
 
     @Test
+    @DirtiesContext
     @WithMockUser(username = "user1")
     public void addRemoveQuestionsForm() throws Exception {
         Survey survey = new Survey("SurveyMonkey", "user1");
@@ -76,6 +82,7 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @DirtiesContext
     @WithMockUser(username = "user1")
     public void saveSurvey() throws Exception {
         this.mockMvc.perform(MockMvcRequestBuilders.get("/saveSurvey"))
@@ -84,6 +91,7 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @DirtiesContext
     @WithMockUser(username = "user1")
     public void saveSurveyName() throws Exception {
         Survey survey = new Survey("SurveyMonkey", "user1");
@@ -96,6 +104,7 @@ public class ControllerStructureTest {
     }
 
     @Test
+    @DirtiesContext
     @WithMockUser(username = "user1")
     public void surveyCreated() throws Exception {
         Survey survey = new Survey("SurveyMonkey", "user1");

--- a/src/test/java/org/group23/ControllerStructureUnauthorizedTest.java
+++ b/src/test/java/org/group23/ControllerStructureUnauthorizedTest.java
@@ -1,0 +1,104 @@
+package org.group23;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class ControllerStructureUnauthorizedTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private SurveyRepository surveyRepository;
+
+    @BeforeEach
+    public void setup() {
+        Survey survey = new Survey("SurveyMonkey", "user1");
+        surveyRepository.save(survey);
+    }
+
+    @Test
+    @DirtiesContext
+    public void createSurveyUnauthenticated() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/createSurvey"))
+                .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("*://*/login"));
+    }
+
+    @Test
+    @DirtiesContext
+    public void surveyEndpointUnauthenticated() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/survey/1"))
+                .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("*://*/login"));
+    }
+
+    @Test
+    @DirtiesContext
+    public void questionEndpointUnauthenticated() throws Exception {
+        this.mockMvc.perform(post("/questions")
+                .with(csrf())
+                .accept("application/json")
+                .content("{\"question\": \"Who are you?\"}"))
+                .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("*://*/login"));
+    }
+
+    @Test
+    @DirtiesContext
+    @WithMockUser(username = "user2")
+    public void addQuestionWrongUser() throws Exception {
+        Survey survey = new Survey("SurveyMonkey", "user1");
+        this.surveyRepository.save(survey);
+
+        String textQuestion = "Who is Joe?";
+
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/addQuestion/{surveyId}", survey.getId())
+                        .param("questionText", textQuestion).with(csrf()))
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
+                .andExpect(MockMvcResultMatchers.view().name("error"));
+    }
+
+    @Test
+    @DirtiesContext
+    @WithMockUser(username = "user2")
+    public void deleteQuestionWrongUser() throws Exception {
+        Survey survey = new Survey("SurveyMonkey", "user1");
+        this.surveyRepository.save(survey);
+
+        Question question = new TextQuestion("Who is Joe?");
+        survey.addQuestion(question);
+        this.surveyRepository.save(survey);
+
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/deleteQuestion/{surveyId}/{questionId}", survey.getId(), question.getId())
+                        .with(csrf()))
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
+                .andExpect(MockMvcResultMatchers.view().name("error"));
+    }
+
+    @Test
+    @DirtiesContext
+    @WithMockUser(username = "user2")
+    public void addRemoveQuestionsWrongUser() throws Exception {
+        Survey survey = new Survey("SurveyMonkey", "user1");
+        this.surveyRepository.save(survey);
+
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/addRemoveQuestions/{id}", survey.getId()))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("error"));
+    }
+
+}

--- a/src/test/java/org/group23/QuestionRepositoryEndpointTest.java
+++ b/src/test/java/org/group23/QuestionRepositoryEndpointTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -43,6 +44,7 @@ public class QuestionRepositoryEndpointTest {
 
     @Test
     @DirtiesContext
+    @WithMockUser(username = "user1")
     public void shouldReturnQuestions() throws Exception {
         this.mockMvc.perform(get("/questions")).andDo(print()).andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.questions").isArray());
@@ -50,6 +52,7 @@ public class QuestionRepositoryEndpointTest {
 
     @Test
     @DirtiesContext
+    @WithMockUser(username = "user1")
     public void shouldAddQuestion() throws Exception {
         MvcResult result = this.mockMvc.perform(get("/questions")).andDo(print()).andReturn();
         JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());
@@ -66,6 +69,7 @@ public class QuestionRepositoryEndpointTest {
 
     @Test
     @DirtiesContext
+    @WithMockUser(username = "user1")
     public void shouldRemoveQuestion() throws Exception {
         MvcResult result = this.mockMvc
                 .perform(get("/questions"))
@@ -86,6 +90,7 @@ public class QuestionRepositoryEndpointTest {
 
     @Test
     @DirtiesContext
+    @WithMockUser(username = "user1")
     public void shouldRemoveQuestionFromSurvey() throws Exception {
         MvcResult result = this.mockMvc
                 .perform(get("/surveys/1/questions"))

--- a/src/test/java/org/group23/QuestionRepositoryEndpointTest.java
+++ b/src/test/java/org/group23/QuestionRepositoryEndpointTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -58,6 +59,7 @@ public class QuestionRepositoryEndpointTest {
         JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());
         int questionCount = jsonObject.getJSONObject("_embedded").getJSONArray("questions").length();
         this.mockMvc.perform(post("/questions")
+                        .with(csrf())
                         .accept("application/json")
                         .content("{\"question\": \"Who are you?\"}"))
                 .andDo(print()).andExpect(status().isCreated());
@@ -79,6 +81,7 @@ public class QuestionRepositoryEndpointTest {
         JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());
         int questionCount = jsonObject.getJSONObject("_embedded").getJSONArray("questions").length();
         this.mockMvc.perform(delete("/questions/3")
+                        .with(csrf())
                         .accept("application/json"))
                 .andDo(print()).andExpect(status().is2xxSuccessful());
         result = this.mockMvc.perform(get("/questions")).andDo(print()).andReturn();
@@ -100,6 +103,7 @@ public class QuestionRepositoryEndpointTest {
         JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());
         int questionCount = jsonObject.getJSONObject("_embedded").getJSONArray("questions").length();
         this.mockMvc.perform(delete("/surveys/1/questions/2")
+                        .with(csrf())
                         .accept("application/json"))
                 .andDo(print()).andExpect(status().is2xxSuccessful());
         result = this.mockMvc.perform(get("/surveys/1/questions")).andDo(print()).andReturn();

--- a/src/test/java/org/group23/SurveyRepositoryEndpointTest.java
+++ b/src/test/java/org/group23/SurveyRepositoryEndpointTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -33,8 +34,8 @@ public class SurveyRepositoryEndpointTest {
         Question q1 = new Question("Test?");
         Question q2 = new Question("Test again?");
         Question q3 = new Question("Not in a survey yet?");
-        Survey s1 = new Survey("Test Survey 1");
-        Survey s2 = new Survey("Test Survey 2");
+        Survey s1 = new Survey("Test Survey 1", "user1");
+        Survey s2 = new Survey("Test Survey 2", "user1");
         s1.addQuestion(q1);
         s1.addQuestion(q2);
         surveyRepository.save(s1); // Cascade saves questions in the survey
@@ -43,6 +44,7 @@ public class SurveyRepositoryEndpointTest {
     }
 
     @Test
+    @WithMockUser(username = "user1")
     public void shouldReturnSurveys() throws Exception {
         this.mockMvc.perform(get("/surveys")).andDo(print()).andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.surveys").isArray());
@@ -50,6 +52,7 @@ public class SurveyRepositoryEndpointTest {
 
     @Test
     @DirtiesContext
+    @WithMockUser(username = "user1")
     public void shouldAddSurvey() throws Exception {
         MvcResult result = this.mockMvc.perform(get("/surveys")).andDo(print()).andReturn();
         JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());
@@ -67,6 +70,7 @@ public class SurveyRepositoryEndpointTest {
 
     @Test
     @DirtiesContext
+    @WithMockUser(username = "user1")
     public void shouldRemoveSurvey() throws Exception {
         MvcResult result = this.mockMvc.perform(get("/surveys")).andDo(print()).andReturn();
         JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());

--- a/src/test/java/org/group23/SurveyRepositoryEndpointTest.java
+++ b/src/test/java/org/group23/SurveyRepositoryEndpointTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -58,6 +59,7 @@ public class SurveyRepositoryEndpointTest {
         JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());
         int addressBookCount = jsonObject.getJSONObject("_embedded").getJSONArray("surveys").length();
         this.mockMvc.perform(post("/surveys")
+                        .with(csrf())
                         .accept("application/json")
                         .content("{\"id\": 5}"))
                 .andDo(print()).andExpect(status().isCreated());
@@ -76,6 +78,7 @@ public class SurveyRepositoryEndpointTest {
         JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());
         int addressBookCount = jsonObject.getJSONObject("_embedded").getJSONArray("surveys").length();
         this.mockMvc.perform(delete("/surveys/2")
+                        .with(csrf())
                         .accept("application/json"))
                 .andDo(print()).andExpect(status().is2xxSuccessful());
         result = this.mockMvc.perform(get("/surveys")).andDo(print()).andReturn();

--- a/src/test/java/org/group23/SurveyRepositoryTest.java
+++ b/src/test/java/org/group23/SurveyRepositoryTest.java
@@ -23,7 +23,7 @@ public class SurveyRepositoryTest {
     @Test
     @DirtiesContext
     public void saveSurvey() {
-        var s1 = new Survey("Test Survey 1");
+        var s1 = new Survey("Test Survey 1", "admin");
 
         surveyRepository.save(s1);
 
@@ -35,8 +35,8 @@ public class SurveyRepositoryTest {
     public void getSurveyById() {
         var name1 = "Test Survey 1";
         var name2 = "Test Survey 2";
-        var s1 = new Survey(name1);
-        var s2 = new Survey(name2);
+        var s1 = new Survey(name1, "admin");
+        var s2 = new Survey(name2, "admin");
         surveyRepository.save(s1);
         surveyRepository.save(s2);
 
@@ -54,8 +54,8 @@ public class SurveyRepositoryTest {
     public void getSurveyByName() {
         var name1 = "Test Survey 1";
         var name2 = "Test Survey 2";
-        var s1 = new Survey(name1);
-        var s2 = new Survey(name2);
+        var s1 = new Survey(name1, "admin");
+        var s2 = new Survey(name2, "admin");
         surveyRepository.save(s1);
         surveyRepository.save(s2);
 
@@ -73,7 +73,7 @@ public class SurveyRepositoryTest {
     public void saveSurveyCascadeSavesQuestions() {
         var q1 = new TextQuestion("Test Question 1?");
         var q2 = new TextQuestion("Test Question 2?");
-        var s1 = new Survey("Test Survey 1");
+        var s1 = new Survey("Test Survey 1", "admin");
         s1.addQuestion(q1);
         s1.addQuestion(q2);
 
@@ -90,7 +90,7 @@ public class SurveyRepositoryTest {
     public void addQuestionToSurveyPropagates() {
         var q1 = new TextQuestion("Test Question 1?");
         var q2 = new TextQuestion("Test Question 2?");
-        var s1 = new Survey("Test Survey 1");
+        var s1 = new Survey("Test Survey 1", "admin");
         s1.addQuestion(q1);
         surveyRepository.save(s1);
         // Check that initialization was correct
@@ -113,7 +113,7 @@ public class SurveyRepositoryTest {
     public void removeQuestionFromSurveyDoesNotPropagate() {
         var q1 = new TextQuestion("Test Question 1?");
         var q2 = new TextQuestion("Test Question 2?");
-        var s1 = new Survey("Test Survey 1");
+        var s1 = new Survey("Test Survey 1", "admin");
         s1.addQuestion(q1);
         s1.addQuestion(q2);
         surveyRepository.save(s1);

--- a/src/test/java/org/group23/SurveyTest.java
+++ b/src/test/java/org/group23/SurveyTest.java
@@ -17,7 +17,7 @@ public class SurveyTest {
 
     @BeforeEach
     public void setup(){
-        survey1 = new Survey("Survey 1");
+        survey1 = new Survey("Survey 1", "admin");
         questions = new ArrayList<>();
         question1 = new TextQuestion("What's your name?");
         question2 = new TextQuestion("What's your favorite color?");


### PR DESCRIPTION
Resolves #30, at least in part.
Changes:

- A rudimentary login screen has been added.
- A rudimentary navigation element has been added to the top of each view, except login.  This includes a logout option, and is present regardless of the user being logged in.
- Three users are defined manually; no further users can be registered (this will be eventually swapped out, but it works for demonstration).
- Access to _any_ endpoint aside from login and the home page requires authentication first.
- Surveys now have an "author", and creating a survey correctly sets this field.
- Access to the edit page of a specific survey, as well as to the POST endpoints for adding/removing questions from that survey, requires the authenticated user to be the author of that survey.
- The deleteQuestion endpoint has been converted from a GET endpoint to a POST endpoint... it already worked like one anyways.
- Existing tests have been updated to not break horribly due to reduced privileges.
- New tests have been added to test that access with insufficient privileges is correctly implemented.

More tests to be added, specifically to test what happens when access is attempted to an endpoint with insufficient permissions.
Also, will need to look through at how to un-expose the CRUD endpoints, or lock them behind admin privileges.