### PR TITLE
Fixed logout banner for demo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,6 +1,12 @@
 <!-- This is a reusable fragment that should be added at the top of every page (except login). -->
-<header>
-    <nav>
+<header xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+    <div sec:authorize="isAuthenticated()">
+        Logged in as: <span sec:authentication="name"></span>
+    </div>
+    <div sec:authorize="!isAuthenticated()">
+        Not logged in
+    </div>
+    <nav sec:authorize="isAuthenticated()">
         <a href="/">Home</a>
         <form th:action="@{/logout}" method="post" style="display: inline;">
             <div><input type="submit" value="Sign Out"/></div>


### PR DESCRIPTION
Logout banner now shows the logged-in username if applicable, or "Not logged in" otherwise. The navigation options are also disabled if the user is not logged in.

![image](https://github.com/Andrei486/sysc-4806-project/assets/55627866/45928be6-99d7-4a33-9f8c-57b0e731cf9c)
![image](https://github.com/Andrei486/sysc-4806-project/assets/55627866/02f2d22c-5b8b-4db4-b1b2-e578e42e9179)
