### PR TITLE
Added answer page for text and numerical questions

### DIFF
--- a/src/main/java/org/group23/MCQuestion.java
+++ b/src/main/java/org/group23/MCQuestion.java
@@ -50,15 +50,25 @@ public class MCQuestion extends Question {
     }
 
     public void setAnswers(Collection<String> answers) {
+        for (String answer: answers) {
+            validateAnswer(answer);
+        }
         this.answers = answers;
     }
 
-//    /**
-//     * Adds a new answer
-//     * @param answer {String}
-//     */
-//    public void addAnswer(String answer) {
-//        this.answers.add(answer);
-//    }
+    /**
+     * Adds a new answer
+     * @param rawAnswer {String}
+     */
+    @Override
+    public void addAnswer(String rawAnswer) {
+        validateAnswer(rawAnswer);
+        this.answers.add(rawAnswer);
+    }
 
+    private void validateAnswer(String answer) {
+        if (!options.contains(answer)) {
+            throw new IllegalArgumentException("Answer must be one of the given options.");
+        }
+    }
 }

--- a/src/main/java/org/group23/NumericalQuestion.java
+++ b/src/main/java/org/group23/NumericalQuestion.java
@@ -35,6 +35,16 @@ public class NumericalQuestion extends Question {
         return numericalAnswers;
     }
 
+    private void addNumericalAnswer(Double answer){
+        validateNumericalAnswer(answer);
+        this.numericalAnswers.add(answer);
+    }
+
+    @Override
+    public void addAnswer(String rawAnswer) {
+        addNumericalAnswer(Double.parseDouble(rawAnswer));
+    }
+
     public Double getMinBound() {
         return minBound;
     }
@@ -53,10 +63,12 @@ public class NumericalQuestion extends Question {
         this.maxBound = maxBound;
     }
 
-    public void setNumericalAnswers(Double numericalAnswer) {
-        validateNumericalAnswer(numericalAnswer);
+    public void setNumericalAnswers(List<Double> newAnswers) {
+        for (Double answer : newAnswers) {
+            validateNumericalAnswer(answer);
+        }
         numericalAnswers.clear();
-        numericalAnswers.add(numericalAnswer);
+        numericalAnswers.addAll(newAnswers);
     }
 
     private void validateNumericalAnswer(Double numericalAnswer) {

--- a/src/main/java/org/group23/NumericalQuestion.java
+++ b/src/main/java/org/group23/NumericalQuestion.java
@@ -63,6 +63,10 @@ public class NumericalQuestion extends Question {
         this.maxBound = maxBound;
     }
 
+    public List<Double> getAnswers() {
+        return numericalAnswers;
+    }
+
     public void setNumericalAnswers(List<Double> newAnswers) {
         for (Double answer : newAnswers) {
             validateNumericalAnswer(answer);

--- a/src/main/java/org/group23/Question.java
+++ b/src/main/java/org/group23/Question.java
@@ -34,4 +34,8 @@ public class Question {
     public void setId(Long id) {
         this.id = id;
     }
+
+    public void addAnswer(String rawAnswer) {
+
+    }
 }

--- a/src/main/java/org/group23/SurveyAnswerController.java
+++ b/src/main/java/org/group23/SurveyAnswerController.java
@@ -1,0 +1,71 @@
+package org.group23;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@Controller
+public class SurveyAnswerController {
+
+    private final String ANSWER_ID_PREFIX = "question_";
+
+    @Autowired
+    private QuestionRepository questionRepository;
+    @Autowired
+    private SurveyRepository surveyRepository;
+
+    @GetMapping("/answerSurvey/{surveyId}")
+    public String showAnswerQuestions(@PathVariable Long surveyId, Model model) {
+        Survey survey = surveyRepository.findById(surveyId).orElse(null);
+        if (survey != null) {
+            model.addAttribute("survey", survey);
+            return "answerSurvey";
+        } else {
+            model.addAttribute("message", "The survey was not found.");
+            return "error";
+        }
+    }
+
+    @PostMapping("/answerSurvey/{surveyId}/submit")
+    public String submitAnswers(
+            @PathVariable Long surveyId,
+            @RequestParam Map<String, String> allParameters,
+            Model model
+    ) {
+        Survey survey = surveyRepository.findById(surveyId).orElse(null);
+        if (survey == null) {
+            model.addAttribute("message", "The survey was not found.");
+            return "error";
+        } else {
+            // Loop over all parameters that correspond to question answers
+            allParameters.keySet().stream().filter(s -> s.startsWith(ANSWER_ID_PREFIX)).forEach(questionIdString -> {
+                long questionId = getQuestionIdFromString(questionIdString);
+                Question question = survey.getQuestions().stream()
+                        .filter(q -> q.getId() == questionId)
+                        .findFirst()
+                        .orElse(null);
+                if (question == null) {
+                    // Ignore if there is no question matching the ID in the survey
+                    return; // Only ends the current iteration in foreach()
+                }
+                question.addAnswer(allParameters.get(questionIdString));
+                questionRepository.save(question);
+            });
+            surveyRepository.save(survey);
+        }
+        model.addAttribute("survey", survey);
+        return "redirect:/answerSurvey/" + surveyId;
+    }
+
+    private long getQuestionIdFromString(String questionIdString) {
+        if (!questionIdString.startsWith(ANSWER_ID_PREFIX)) {
+            throw new IllegalArgumentException(
+                    String.format("String %s does not correspond to a question ID.", questionIdString));
+        }
+        String[] splits = questionIdString.split("_");
+        return Long.parseLong(splits[splits.length-1]);
+    }
+}

--- a/src/main/java/org/group23/TextQuestion.java
+++ b/src/main/java/org/group23/TextQuestion.java
@@ -21,6 +21,7 @@ public class TextQuestion extends Question {
         this.answers = new ArrayList<>();
     }
 
+    @Override
     public void addAnswer(String answer){
         this.answers.add(answer);
     }

--- a/src/main/resources/templates/answerSurvey.html
+++ b/src/main/resources/templates/answerSurvey.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Title</title>
 </head>
 <body>

--- a/src/main/resources/templates/answerSurvey.html
+++ b/src/main/resources/templates/answerSurvey.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <div th:replace="fragments/header"></div>
+    <h1 th:text="'Survey: ' + ${survey.name}"></h1>
+    <form th:action="@{/answerSurvey/{surveyId}/submit(surveyId=${survey.id})}" method="post">
+        <div th:each="question : ${survey.questions}">
+            <div th:if="${question.class.name == 'org.group23.TextQuestion'}">
+                <div th:replace="fragments/textQuestionAnswerForm"></div>
+            </div>
+            <div th:if="${question.class.name == 'org.group23.NumericalQuestion'}">
+                <div th:replace="fragments/numericalQuestionAnswerForm"></div>
+            </div>
+        </div>
+
+        <input type="submit"/>
+    </form>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/numericalQuestionAnswerForm.html
+++ b/src/main/resources/templates/fragments/numericalQuestionAnswerForm.html
@@ -1,5 +1,11 @@
 <!-- This is a reusable fragment used to generate answer forms for a numerical question. -->
 <div>
-    <label th:for="'question_' + ${question.id}" th:text="${question.question}"></label><br>
-    <input type="number" th:min="${question.minBound}" th:max="${question.maxBound}" th:id="'question_' + ${question.id}" required/><br>
+    <label th:for="'question_' + ${question.id}" th:text="${question.question}"></label><br/>
+    <input
+            type="number"
+            th:min="${question.minBound}"
+            th:max="${question.maxBound}"
+            th:id="'question_' + ${question.id}"
+            th:name="'question_' + ${question.id}"
+            th:required="required"/><br/>
 </div>

--- a/src/main/resources/templates/fragments/numericalQuestionAnswerForm.html
+++ b/src/main/resources/templates/fragments/numericalQuestionAnswerForm.html
@@ -1,0 +1,5 @@
+<!-- This is a reusable fragment used to generate answer forms for a numerical question. -->
+<div>
+    <label th:for="'question_' + ${question.id}" th:text="${question.question}"></label><br>
+    <input type="number" th:min="${question.minBound}" th:max="${question.maxBound}" th:id="'question_' + ${question.id}" required/><br>
+</div>

--- a/src/main/resources/templates/fragments/textQuestionAnswerForm.html
+++ b/src/main/resources/templates/fragments/textQuestionAnswerForm.html
@@ -1,5 +1,5 @@
 <!-- This is a reusable fragment used to generate answer forms for a text question. -->
 <div>
-    <label th:for="'question_' + ${question.id}" th:text="${question.question}"></label><br>
-    <input type="text" th:id="${question.id}" th:name="'question_' + ${question.id}" required/><br>
+    <label th:for="'question_' + ${question.id}" th:text="${question.question}"></label><br/>
+    <input type="text" th:id="'question_' + ${question.id}" th:name="'question_' + ${question.id}" th:required="required"/><br/>
 </div>

--- a/src/main/resources/templates/fragments/textQuestionAnswerForm.html
+++ b/src/main/resources/templates/fragments/textQuestionAnswerForm.html
@@ -1,0 +1,5 @@
+<!-- This is a reusable fragment used to generate answer forms for a text question. -->
+<div>
+    <label th:for="'question_' + ${question.id}" th:text="${question.question}"></label><br>
+    <input type="text" th:id="${question.id}" th:name="'question_' + ${question.id}" required/><br>
+</div>

--- a/src/test/java/org/group23/NumericalQuestionTest.java
+++ b/src/test/java/org/group23/NumericalQuestionTest.java
@@ -14,7 +14,7 @@ class NumericalQuestionTest {
 
         // Set a valid numerical answer within the specified range
         Double validAnswer = 50.0;
-        numericalQuestion.setNumericalAnswers(validAnswer);
+        numericalQuestion.setNumericalAnswers(Collections.singletonList(validAnswer));
 
         // Verify that the answer is set correctly
         assertEquals(Collections.singletonList(validAnswer), numericalQuestion.getNumericalAnswers());
@@ -26,7 +26,7 @@ class NumericalQuestionTest {
         // Set an invalid numerical answer (outside the specified range)
         Double invalidAnswer = 150.0;
         assertThrows(IllegalArgumentException.class, () -> {
-            numericalQuestion.setNumericalAnswers(invalidAnswer);
+            numericalQuestion.setNumericalAnswers(Collections.singletonList(invalidAnswer));
         });
         // Verify that the answer list remains empty
         assertTrue(numericalQuestion.getNumericalAnswers().isEmpty());
@@ -35,14 +35,14 @@ class NumericalQuestionTest {
     @Test
     public void addNumericalAnswer_withinRange_shouldAddAnswerToList() {
         NumericalQuestion numericalQuestion = new NumericalQuestion("Test Numerical Question", 0.0, 100.0);
-        numericalQuestion.setNumericalAnswers(50.0);
+        numericalQuestion.setNumericalAnswers(Collections.singletonList(50.0));
         assertEquals(Arrays.asList(50.0), numericalQuestion.getNumericalAnswers());
     }
 
     @Test
     public void addNumericalAnswer_outsideRange_shouldThrowException() {
         NumericalQuestion numericalQuestion = new NumericalQuestion("Test Numerical Question", 0.0, 100.0);
-        assertThrows(IllegalArgumentException.class, () -> numericalQuestion.setNumericalAnswers(150.0));
+        assertThrows(IllegalArgumentException.class, () -> numericalQuestion.setNumericalAnswers(Collections.singletonList(150.0)));
         assertTrue(numericalQuestion.getNumericalAnswers().isEmpty());
     }
 

--- a/src/test/java/org/group23/SurveyAnswerControllerTest.java
+++ b/src/test/java/org/group23/SurveyAnswerControllerTest.java
@@ -1,0 +1,86 @@
+package org.group23;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class SurveyAnswerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private SurveyRepository surveyRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    private final String ANSWER_ID_PREFIX = "question_";
+
+    private long surveyId;
+    private long textQuestionId;
+    private long numericalQuestionId;
+
+    @BeforeEach
+    public void setup() {
+        Survey survey = new Survey("SurveyMonkey", "user1");
+        Question textQuestion = new TextQuestion("Test TextQuestion");
+        Question numericalQuestion = new NumericalQuestion("Test NumericalQuestion", -0.1, 20.0);
+        survey.addQuestion(textQuestion);
+        survey.addQuestion(numericalQuestion);
+        surveyRepository.save(survey); // Also saves questions
+        surveyId = survey.getId();
+        textQuestionId = textQuestion.getId();
+        numericalQuestionId = numericalQuestion.getId();
+    }
+
+    @Test
+    @DirtiesContext
+    @WithMockUser(username = "user2")
+    public void showAnswerPage() throws Exception {
+        String textQuestionIdString = ANSWER_ID_PREFIX + textQuestionId;
+        String numericalQuestionIdString = ANSWER_ID_PREFIX + numericalQuestionId;
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/answerSurvey/{surveyId}", surveyId))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("answerSurvey"))
+                .andExpect(xpath(String.format("//input[@name=\"%s\" and @type=\"text\"]", textQuestionIdString)).exists())
+                .andExpect(xpath(String.format("//input[@name=\"%s\" and @type=\"number\" and @min=\"-0.1\" and @max=\"20.0\"]", numericalQuestionIdString)).exists())
+                .andExpect(xpath("//input[@type=\"submit\"]").exists());
+    }
+
+    @Test
+    @DirtiesContext
+    @Transactional
+    @WithMockUser(username = "user2")
+    public void submitAnswers() throws Exception {
+        String textQuestionIdString = ANSWER_ID_PREFIX + textQuestionId;
+        String numericalQuestionIdString = ANSWER_ID_PREFIX + numericalQuestionId;
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/answerSurvey/{surveyId}/submit", surveyId)
+                        .param(textQuestionIdString, "Text Answer")
+                        .param(numericalQuestionIdString, "10.23")
+                        .with(csrf()))
+                .andExpect(MockMvcResultMatchers.status().is3xxRedirection());
+        TextQuestion textQuestion = (TextQuestion) questionRepository.findById(textQuestionId).orElse(null);
+        assertNotNull(textQuestion);
+        NumericalQuestion numericalQuestion = (NumericalQuestion) questionRepository.findById(numericalQuestionId).orElse(null);
+        assertNotNull(numericalQuestion);
+        assertEquals(1, textQuestion.getAnswers().size());
+        assertTrue(textQuestion.getAnswers().contains("Text Answer"));
+        assertEquals(1, numericalQuestion.getAnswers().size());
+        assertTrue(numericalQuestion.getAnswers().contains(10.23));
+    }
+}


### PR DESCRIPTION
Closes issue #26 (and #28 maybe).

New endpoints:

- GET answerSurvey/{id}: shows a page to answer all the questions in the survey
- POST answerSurvey/{id}/submit: submits all answers

No unit/integration tests for now, those will be added - for now, confirmed it worked by creating a survey, answering it, and then visiting /surveys/1/questions (JSON endpoint) to make sure answers were there. Answers were able to be added repeatedly for text questions. For numerical questions the only testing done was manual.

Notes:
The answer form for a question is generated based on the question class - this introduces a lot of coupling for now, but does allow us to smoothly add additional Question subclasses like MCQ.
All Question subclasses should now override the `public void addAnswer(String rawAnswer)` method, which is used to add answers from string form to the question. This has been added for TextQuestion (which pretty much had it already) and NumericalQuestion.

Still missing:
- Unit/integration tests using both numeric and text questions