### PR TITLE
Delete Survey Fix

### DIFF
--- a/src/main/java/org/group23/ControllerStructure.java
+++ b/src/main/java/org/group23/ControllerStructure.java
@@ -135,7 +135,7 @@ public class ControllerStructure {
         }
     }
 
-    @DeleteMapping("/deleteSurvey/{surveyId}")
+    @PostMapping("/deleteSurvey/{surveyId}")
     public String deleteSurvey(@PathVariable Long surveyId, Model model) {
         // Get the survey by ID
         Survey survey = surveyRepository.findById(surveyId).orElse(null);

--- a/src/main/resources/templates/addRemoveQuestions.html
+++ b/src/main/resources/templates/addRemoveQuestions.html
@@ -40,7 +40,7 @@
     </form>
     <!-- Form to delete the entire survey -->
     <form th:action="@{/deleteSurvey/{surveyId}(surveyId=${survey.id})}" method="post">
-        <input type="hidden" name="_method" value="delete" />
+        <!--input type="hidden" name="_method" value="delete" /-->
         <input type="submit" value="Delete Survey">
     </form>
 </body>

--- a/src/test/java/org/group23/ControllerStructureTest.java
+++ b/src/test/java/org/group23/ControllerStructureTest.java
@@ -131,7 +131,7 @@ public class ControllerStructureTest {
         Survey survey = new Survey("SurveyMonkey", "user1");
         this.surveyRepository.save(survey);
 
-        this.mockMvc.perform(MockMvcRequestBuilders.delete("/deleteSurvey/{surveyId}", survey.getId())
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/deleteSurvey/{surveyId}", survey.getId())
                         .with(csrf()))
                 .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
                 .andExpect(MockMvcResultMatchers.view().name("redirect:/createSurvey"))

--- a/src/test/java/org/group23/ControllerStructureUnauthorizedTest.java
+++ b/src/test/java/org/group23/ControllerStructureUnauthorizedTest.java
@@ -108,7 +108,7 @@ public class ControllerStructureUnauthorizedTest {
         Survey survey = new Survey("SurveyMonkey", "user1");
         this.surveyRepository.save(survey);
 
-        this.mockMvc.perform(MockMvcRequestBuilders.delete("/deleteSurvey/{surveyId}", survey.getId())
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/deleteSurvey/{surveyId}", survey.getId())
                         .with(csrf()))
                 .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
                 .andExpect(MockMvcResultMatchers.view().name("error"));


### PR DESCRIPTION
Changed delete to post because delete request was not working. Not sure how the workaround mentioned was supposed to work but it is currently not working on deployment.