### PR TITLE
Fixed MC name options, also made endpoint tests delete all from repos

### DIFF
--- a/src/main/java/org/group23/AddRemoveQuestionController.java
+++ b/src/main/java/org/group23/AddRemoveQuestionController.java
@@ -115,7 +115,7 @@ public class AddRemoveQuestionController {
             @PathVariable Long surveyId,
             @ModelAttribute("survey") Survey survey,
             @RequestParam String questionText,
-            @RequestParam Map<String, String> allParameters,
+            @RequestParam(name="mcOption") List<String> mcOptions,
             Model model
     ) {
         // Validate length before adding to the database
@@ -132,13 +132,12 @@ public class AddRemoveQuestionController {
             // Create a text question and add it to the survey
             List<String> options = new LinkedList<>();
             // Find all MC options in parameters
-            allParameters.keySet().stream().filter(s -> s.startsWith("mcOption")).forEach(mcOptionKey -> {
-                String option = allParameters.get(mcOptionKey);
+            for (String option : mcOptions) {
                 // Don't allow empty options
                 if (!option.isBlank()) {
                     options.add(option);
                 }
-            });
+            }
             // TODO: should we allow MC questions with no option?
             MCQuestion mcQuestion = new MCQuestion(questionText, options);
             updatedSurvey.addQuestion(mcQuestion);

--- a/src/main/resources/templates/addRemoveQuestions.html
+++ b/src/main/resources/templates/addRemoveQuestions.html
@@ -40,17 +40,17 @@
         <ul id="mcOptions">
             <li>
                 <label>
-                    <input type="text" name="mcOption1"/>
+                    <input type="text" name="mcOption"/>
                 </label>
             </li>
             <li>
                 <label>
-                    <input type="text" name="mcOption2"/>
+                    <input type="text" name="mcOption"/>
                 </label>
             </li>
             <li>
                 <label>
-                    <input type="text" name="mcOption3"/>
+                    <input type="text" name="mcOption"/>
                 </label>
             </li>
         </ul>

--- a/src/test/java/org/group23/ControllerStructureTest.java
+++ b/src/test/java/org/group23/ControllerStructureTest.java
@@ -23,6 +23,7 @@ public class ControllerStructureTest {
 
     @BeforeEach
     public void setup() {
+        surveyRepository.deleteAll();
         Survey survey = new Survey("SurveyMonkey", "user1");
         surveyRepository.save(survey);
     }

--- a/src/test/java/org/group23/ControllerStructureUnauthorizedTest.java
+++ b/src/test/java/org/group23/ControllerStructureUnauthorizedTest.java
@@ -26,6 +26,7 @@ public class ControllerStructureUnauthorizedTest {
 
     @BeforeEach
     public void setup() {
+        surveyRepository.deleteAll();
         Survey survey = new Survey("SurveyMonkey", "user1");
         surveyRepository.save(survey);
     }

--- a/src/test/java/org/group23/QuestionRepositoryEndpointTest.java
+++ b/src/test/java/org/group23/QuestionRepositoryEndpointTest.java
@@ -33,6 +33,8 @@ public class QuestionRepositoryEndpointTest {
 
     @BeforeEach
     public void setup() {
+        surveyRepository.deleteAll();
+        questionRepository.deleteAll();
         Question q1 = new Question("Test?");
         Question q2 = new Question("Test again?");
         Question q3 = new Question("Not in a survey yet?");

--- a/src/test/java/org/group23/SurveyAnswerControllerTest.java
+++ b/src/test/java/org/group23/SurveyAnswerControllerTest.java
@@ -40,6 +40,8 @@ public class SurveyAnswerControllerTest {
 
     @BeforeEach
     public void setup() {
+        surveyRepository.deleteAll();
+        questionRepository.deleteAll();
         Survey survey = new Survey("SurveyMonkey", "user1");
         Question textQuestion = new TextQuestion("Test TextQuestion");
         Question numericalQuestion = new NumericalQuestion("Test NumericalQuestion", -0.1, 20.0);

--- a/src/test/java/org/group23/SurveyRepositoryEndpointTest.java
+++ b/src/test/java/org/group23/SurveyRepositoryEndpointTest.java
@@ -32,6 +32,8 @@ public class SurveyRepositoryEndpointTest {
 
     @BeforeEach
     public void setup() {
+        surveyRepository.deleteAll();
+        questionRepository.deleteAll();
         Question q1 = new Question("Test?");
         Question q2 = new Question("Test again?");
         Question q3 = new Question("Not in a survey yet?");


### PR DESCRIPTION
Resolves #60, also resolves #58.

All MC option fields in the form to add an MC question are now named "mcOption": this makes for cleaner handling and will make it easier to let the user add more options. Changes are in the AddRemoveQuestionsController as well as the HTML view.
All endpoint tests _should_ now have all surveys and questions (where applicable) deleted before the setup for each test, so we can guarantee each test runs from scratch. Check that no files were missed, and make sure to add this in future test files.