### PR TITLE
Added register users page and tests

### DIFF
--- a/src/main/java/org/group23/config/RegisterUserController.java
+++ b/src/main/java/org/group23/config/RegisterUserController.java
@@ -1,0 +1,42 @@
+package org.group23.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class RegisterUserController {
+
+    @Autowired
+    InMemoryUserDetailsManager userDetailsManager;
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @GetMapping("/register")
+    public String showRegistrationForm() {
+        return "register";
+    }
+
+    @PostMapping("/register")
+    public String registerUser(
+            @RequestParam String username,
+            @RequestParam String password
+    ) {
+        if (userDetailsManager.userExists(username)) {
+            return "redirect:/register?userExists";
+        } else {
+            UserDetails user = User.withUsername(username)
+                    .password(passwordEncoder.encode(password))
+                    .roles("USER")
+                    .build();
+            userDetailsManager.createUser(user);
+        }
+        return "redirect:/login";
+    }
+}

--- a/src/main/java/org/group23/config/SecurityConfig.java
+++ b/src/main/java/org/group23/config/SecurityConfig.java
@@ -64,8 +64,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
         http
-                // Allow all requests to the home page
+                // Allow all requests to the home page and registration page
                 .authorizeHttpRequests((requests) -> requests
+                        .requestMatchers(mvc.pattern("/register")).permitAll()
                         .requestMatchers(mvc.pattern("/")).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,15 +1,18 @@
 <!-- This is a reusable fragment that should be added at the top of every page (except login). -->
 <header xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
-    <div sec:authorize="isAuthenticated()">
-        Logged in as: <span sec:authentication="name"></span>
-    </div>
-    <div sec:authorize="!isAuthenticated()">
-        Not logged in
-    </div>
+    <nav sec:authorize="!isAuthenticated()">
+        Not logged in.<br/>
+        <a href="/login">Login</a><br/>
+        <a href="/register">Register</a>
+    </nav>
     <nav sec:authorize="isAuthenticated()">
+        <div sec:authorize="isAuthenticated()">
+            Logged in as: <span sec:authentication="name"></span>
+        </div>
         <a href="/">Home</a>
         <form th:action="@{/logout}" method="post" style="display: inline;">
             <div><input type="submit" value="Sign Out"/></div>
         </form>
     </nav>
+    <hr/>
 </header>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -6,9 +6,7 @@
         <a href="/register">Register</a>
     </nav>
     <nav sec:authorize="isAuthenticated()">
-        <div sec:authorize="isAuthenticated()">
-            Logged in as: <span sec:authentication="name"></span>
-        </div>
+        Logged in as: <span sec:authentication="name"></span>
         <a href="/">Home</a>
         <form th:action="@{/logout}" method="post" style="display: inline;">
             <div><input type="submit" value="Sign Out"/></div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -4,16 +4,21 @@
         <title>Mini Survey Monkey - Login</title>
     </head>
     <body>
+        <div th:replace="fragments/header"></div>
+        <h1>Login</h1>
+        <form th:action="@{/login}" method="post">
+            <div><label> User Name: <input type="text" name="username"/> </label></div>
+            <div><label> Password: <input type="password" name="password"/> </label></div>
+            <div><input type="submit" value="Sign In"/></div>
+        </form>
+        <div th:if="${param.registered}"> <!-- A user coming from a successful registration will arrive to this page with this URL param set. -->
+            Account successfully registered!
+        </div>
         <div th:if="${param.error}"> <!-- A user that fails a login will arrive to this page with this URL param set. -->
             Invalid username and password.
         </div>
         <div th:if="${param.logout}"> <!-- A user logging out will arrive to this page with this URL param set. -->
             You have been logged out.
         </div>
-        <form th:action="@{/login}" method="post">
-            <div><label> User Name : <input type="text" name="username"/> </label></div>
-            <div><label> Password: <input type="password" name="password"/> </label></div>
-            <div><input type="submit" value="Sign In"/></div>
-        </form>
     </body>
 </html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
+    <head>
+        <title>Mini Survey Monkey - Register</title>
+    </head>
+    <body>
+        <div th:replace="fragments/header"></div>
+        <h1>Register</h1>
+        <form th:action="@{/register}" method="post">
+            <div><label> User Name: <input type="text" name="username"/> </label></div>
+            <div><label> Password: <input type="password" name="password"/> </label></div>
+            <div><input type="submit" value="Sign In"/></div>
+        </form>
+        <div th:if="${param.userExists}"> <!-- This parameter will be set if the username entered already exists. -->
+            Username is already taken.
+        </div>
+    </body>
+</html>

--- a/src/test/java/org/group23/RegisterUserControllerTest.java
+++ b/src/test/java/org/group23/RegisterUserControllerTest.java
@@ -1,0 +1,81 @@
+package org.group23;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class RegisterUserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    InMemoryUserDetailsManager userDetailsManager;
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    public void setup() {
+        // Create a test user. Delete both users that could have been created.
+        if (userDetailsManager.userExists("User1")) userDetailsManager.deleteUser("User1");
+        if (userDetailsManager.userExists("User2")) userDetailsManager.deleteUser("User2");
+        UserDetails user = User.withUsername("User1")
+                .password(passwordEncoder.encode("Password1"))
+                .roles("USER")
+                .build();
+        userDetailsManager.createUser(user);
+    }
+
+    @Test
+    @DirtiesContext
+    public void showRegisterPage() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/register"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("register"));
+    }
+
+    @Test
+    @DirtiesContext
+    public void registerNewUser() throws Exception {
+        String username = "User2";
+        String password = "Password2";
+        assertFalse(userDetailsManager.userExists(username));
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/register")
+                        .param("username", username)
+                        .param("password", password)
+                        .with(csrf()))
+                .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(MockMvcResultMatchers.view().name("redirect:/login"));
+        assertTrue(userDetailsManager.userExists(username));
+    }
+
+    @Test
+    @DirtiesContext
+    public void registerExistingUser() throws Exception {
+        String username = "User1";
+        String password = "Password2"; // Password doesn't need to be the same
+        assertTrue(userDetailsManager.userExists(username));
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/register")
+                        .param("username", username)
+                        .param("password", password)
+                        .with(csrf()))
+                .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(MockMvcResultMatchers.view().name("redirect:/register?userExists"));
+        assertTrue(userDetailsManager.userExists(username));
+    }
+}


### PR DESCRIPTION
Resolves #57.

Main code is in RegisterUserController, including handlers for GET and POST.

Changes to the app that should be visible:

- While not signed in, the top banner should now show links to login and register.
- The register page (/register) should provide a username and password field for users to register.
- If a user attempts to register a username that already exists, they should be redirected back to register and there should be a message to that effect.
- If a user successfully registers they should be redirected to the login page.
- The security filter has changed to allow unauthenticated access to the registration page.
- The login and registration page have more obvious headings.

Some tests exist for the new endpoints.